### PR TITLE
Fixed lone number support

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -18,6 +18,10 @@ pub fn parse_number<'b, 'a>(values: &'b mut &'a [u8]) -> Result<Number<'a>, Erro
             is_float = true
         }
         length += 1;
+
+        if values.len() == 1 {
+            break;
+        }
         *values = values.get(1..).ok_or(Error::InvalidEOF)?;
         let byte = values.get(0).ok_or(Error::InvalidEOF)?;
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -232,6 +232,12 @@ fn edges() {
     assert!(parse(br#""\u"""#).is_err());
     assert!(parse(br#""\u1234""#).is_ok());
 
+    assert!(parse(br#"1"#).is_ok());
+    assert!(parse(br#"11"#).is_ok());
+    assert!(parse(br#"1.1"#).is_ok());
+    assert!(parse(br#"1.1E-6"#).is_ok());
+    assert!(parse(br#"1.1e-6"#).is_ok());
+
     assert!(parse(br#"nula"#).is_err());
     assert!(parse(br#"trua"#).is_err());
     assert!(parse(br#"falsa"#).is_err());


### PR DESCRIPTION
I'm glad to see the benchmarking and performance improvements of this library over `serde_json`. When working on updating pola-rs/polars#3413, I noticed that changes in jorgecarleitao/arrow2#1024 had broken support for deserializing numbers on their own (outside of JSON lists or objects). This PR fixes the root cause in the number parsing code, and provides parity with `serde_json` support of lone numbers.

I'm hoping to incorporate these changes into pola-rs/polars#3413, so an update to arrow2 would also be greatly appreciated! :smile: 