### PR TITLE
Fixed parsing lone numbers

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -19,18 +19,20 @@ pub fn parse_number<'b, 'a>(values: &'b mut &'a [u8]) -> Result<Number<'a>, Erro
         }
         length += 1;
 
-        if values.len() == 1 {
-            break;
-        }
-        *values = values.get(1..).ok_or(Error::InvalidEOF)?;
-        let byte = values.get(0).ok_or(Error::InvalidEOF)?;
-
         prev_state = state;
-        state = next_state(*byte, state)?;
 
         if matches!(prev_state, State::Number | State::Fraction) {
             number_end += 1
         };
+
+        if values.len() == 1 {
+            break;
+        }
+
+        *values = values.get(1..).ok_or(Error::InvalidEOF)?;
+        let byte = values.get(0).ok_or(Error::InvalidEOF)?;
+
+        state = next_state(*byte, state)?;
 
         if state == State::Finished {
             break;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -111,11 +111,15 @@ fn empty_string() -> Result<(), Error> {
 
 #[test]
 fn number() -> Result<(), Error> {
-    let data: &str = "[10]";
+    let num: &str = "10";
+    let array: &str = &format!("[{}]", num);
 
-    let item = parse(data.as_bytes())?;
     assert_eq!(
-        item,
+        parse(num.as_bytes())?,
+        Value::Number(Number::Integer(b"10", b""))
+    );
+    assert_eq!(
+        parse(array.as_bytes())?,
         Value::Array(vec![Value::Number(Number::Integer(b"10", b""))])
     );
     Ok(())
@@ -176,11 +180,15 @@ fn multiple_escape() -> Result<(), Error> {
 
 #[test]
 fn number_exponent() -> Result<(), Error> {
-    let data: &[u8] = b"[1E10]";
+    let num: &str = "1E10";
+    let array: &str = &format!("[{}]", num);
 
-    let item = parse(data)?;
     assert_eq!(
-        item,
+        parse(num.as_bytes())?,
+        Value::Number(Number::Integer(b"1", b"10"))
+    );
+    assert_eq!(
+        parse(array.as_bytes())?,
         Value::Array(vec![Value::Number(Number::Integer(b"1", b"10"))])
     );
     Ok(())
@@ -188,11 +196,15 @@ fn number_exponent() -> Result<(), Error> {
 
 #[test]
 fn number_exponent1() -> Result<(), Error> {
-    let data: &[u8] = b"[1e-10]";
+    let num: &str = "1e-10";
+    let array: &str = &format!("[{}]", num);
 
-    let item = parse(data)?;
     assert_eq!(
-        item,
+        parse(num.as_bytes())?,
+        Value::Number(Number::Integer(b"1", b"-10"))
+    );
+    assert_eq!(
+        parse(array.as_bytes())?,
         Value::Array(vec![Value::Number(Number::Integer(b"1", b"-10"))])
     );
     Ok(())
@@ -200,15 +212,16 @@ fn number_exponent1() -> Result<(), Error> {
 
 #[test]
 fn number_exponent2() -> Result<(), Error> {
-    let data: &[u8] = b"[8.310346185542391e275]";
+    let num: &str = "8.310346185542391e275";
+    let array: &str = &format!("[{}]", num);
 
-    let item = parse(data)?;
     assert_eq!(
-        item,
-        Value::Array(vec![Value::Number(Number::Float(
-            b"8.310346185542391",
-            b"275"
-        ))])
+        parse(num.as_bytes())?,
+        Value::Number(Number::Float(b"8.310346185542391", b"275"))
+    );
+    assert_eq!(
+        parse(array.as_bytes())?,
+        Value::Array(vec![Value::Number(Number::Float(b"8.310346185542391", b"275"))])
     );
     Ok(())
 }


### PR DESCRIPTION
This PR follows #13, which addressed issues with numbers on their own failing to deserialized. That solution was only a partial fix, because the tests were not rigorous enough to assert that the values were correct. :disappointed: I've updated the tests to explicitly assert the values are correct, and realized I had been missing the `number_end` increment, which was causing the numbers to be truncated. I reordered the operations in parse_number to fix that.